### PR TITLE
updating libspread-util copyright date and version

### DIFF
--- a/prime/libspread-util/docs/Readme.txt
+++ b/prime/libspread-util/docs/Readme.txt
@@ -3,7 +3,7 @@ SPREAD: A Reliable Multicast and Group Communication Toolkit
 
 /===========================================================================\
 | The Spread Group Communication Toolkit Utility Library                    |
-| Copyright (c) 1993-2016 Spread Concepts LLC                               |
+| Copyright (c) 1993-2024 Spread Concepts LLC                               |
 | All rights reserved.                                                      |
 |                                                                           |
 | The Spread package is licensed under the Spread Open-Source License.      |
@@ -48,7 +48,7 @@ SPREAD: A Reliable Multicast and Group Communication Toolkit
 | WWW    : http://www.spread.org  and  http://www.spreadconcepts.com        |
 | Contact: info@spreadconcepts.com                                          |
 |                                                                           |
-| Version 5.0.0 built 1/Feb/2017                                            |
+| Version 5.1.0 built 29/Feb/2024                                            |
 \===========================================================================/
 
 February 1, 2017 Ver 5.0.0

--- a/prime/libspread-util/docs/license.txt
+++ b/prime/libspread-util/docs/license.txt
@@ -1,6 +1,6 @@
 Spread Open-Source License -- Version 1.0
 -----------------------------------------
-Copyright (c) 1993-2016 Spread Concepts LLC.  All rights reserved.
+Copyright (c) 1993-2024 Spread Concepts LLC.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/prime/libspread-util/include/spu_addr.h
+++ b/prime/libspread-util/include/spu_addr.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_alarm.h
+++ b/prime/libspread-util/include/spu_alarm.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_alarm_types.h
+++ b/prime/libspread-util/include/spu_alarm_types.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_data_link.h
+++ b/prime/libspread-util/include/spu_data_link.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_events.h
+++ b/prime/libspread-util/include/spu_events.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_memory.h
+++ b/prime/libspread-util/include/spu_memory.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_objects.h
+++ b/prime/libspread-util/include/spu_objects.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_objects_local.h
+++ b/prime/libspread-util/include/spu_objects_local.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_scatter.h
+++ b/prime/libspread-util/include/spu_scatter.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_system_defs.h
+++ b/prime/libspread-util/include/spu_system_defs.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_system_defs_autoconf.h
+++ b/prime/libspread-util/include/spu_system_defs_autoconf.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/include/spu_system_defs_windows.h
+++ b/prime/libspread-util/include/spu_system_defs_windows.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/alarm.c
+++ b/prime/libspread-util/src/alarm.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/arch.c
+++ b/prime/libspread-util/src/arch.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/arch.h
+++ b/prime/libspread-util/src/arch.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/data_link.c
+++ b/prime/libspread-util/src/data_link.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/defines.h
+++ b/prime/libspread-util/src/defines.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/events.c
+++ b/prime/libspread-util/src/events.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/memory.c
+++ b/prime/libspread-util/src/memory.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/prime/libspread-util/src/spu_addr.c
+++ b/prime/libspread-util/src/spu_addr.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/docs/Readme.txt
+++ b/spines/libspread-util/docs/Readme.txt
@@ -3,7 +3,7 @@ SPREAD: A Reliable Multicast and Group Communication Toolkit
 
 /===========================================================================\
 | The Spread Group Communication Toolkit Utility Library                    |
-| Copyright (c) 1993-2016 Spread Concepts LLC                               |
+| Copyright (c) 1993-2024 Spread Concepts LLC                               |
 | All rights reserved.                                                      |
 |                                                                           |
 | The Spread package is licensed under the Spread Open-Source License.      |
@@ -48,7 +48,7 @@ SPREAD: A Reliable Multicast and Group Communication Toolkit
 | WWW    : http://www.spread.org  and  http://www.spreadconcepts.com        |
 | Contact: info@spreadconcepts.com                                          |
 |                                                                           |
-| Version 5.0.0 built 1/Feb/2017                                            |
+| Version 5.1.0 built 29/Feb/2024                                            |
 \===========================================================================/
 
 February 1, 2017 Ver 5.0.0

--- a/spines/libspread-util/docs/license.txt
+++ b/spines/libspread-util/docs/license.txt
@@ -1,6 +1,6 @@
 Spread Open-Source License -- Version 1.0
 -----------------------------------------
-Copyright (c) 1993-2016 Spread Concepts LLC.  All rights reserved.
+Copyright (c) 1993-2024 Spread Concepts LLC.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/spines/libspread-util/include/spu_addr.h
+++ b/spines/libspread-util/include/spu_addr.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_alarm.h
+++ b/spines/libspread-util/include/spu_alarm.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_alarm_types.h
+++ b/spines/libspread-util/include/spu_alarm_types.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_data_link.h
+++ b/spines/libspread-util/include/spu_data_link.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_events.h
+++ b/spines/libspread-util/include/spu_events.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_memory.h
+++ b/spines/libspread-util/include/spu_memory.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_objects.h
+++ b/spines/libspread-util/include/spu_objects.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_objects_local.h
+++ b/spines/libspread-util/include/spu_objects_local.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_scatter.h
+++ b/spines/libspread-util/include/spu_scatter.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_system_defs.h
+++ b/spines/libspread-util/include/spu_system_defs.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_system_defs_autoconf.h
+++ b/spines/libspread-util/include/spu_system_defs_autoconf.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/include/spu_system_defs_windows.h
+++ b/spines/libspread-util/include/spu_system_defs_windows.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/alarm.c
+++ b/spines/libspread-util/src/alarm.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/arch.c
+++ b/spines/libspread-util/src/arch.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/arch.h
+++ b/spines/libspread-util/src/arch.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/data_link.c
+++ b/spines/libspread-util/src/data_link.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/defines.h
+++ b/spines/libspread-util/src/defines.h
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/events.c
+++ b/spines/libspread-util/src/events.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/memory.c
+++ b/spines/libspread-util/src/memory.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.

--- a/spines/libspread-util/src/spu_addr.c
+++ b/spines/libspread-util/src/spu_addr.c
@@ -18,13 +18,13 @@
  * The Creators of Spread are:
  *  Yair Amir, Michal Miskin-Amir, Jonathan Stanton, John Schultz.
  *
- *  Copyright (C) 1993-2016 Spread Concepts LLC <info@spreadconcepts.com>
+ *  Copyright (C) 1993-2024 Spread Concepts LLC <info@spreadconcepts.com>
  *
  *  All Rights Reserved.
  *
  * Major Contributor(s):
  * ---------------
- *    Amy Babay            babay@cs.jhu.edu - accelerated ring protocol.
+ *    Amy Babay            babay@pitt.edu - accelerated ring protocol.
  *    Ryan Caudy           rcaudy@gmail.com - contributions to process groups.
  *    Claudiu Danilov      claudiu@acm.org - scalable wide area support.
  *    Cristina Nita-Rotaru crisn@cs.purdue.edu - group communication security.


### PR DESCRIPTION
Updates copyright to 2024, release date to February 29, 2024, version to 5.1.0, and Amy's email to pitt.edu