### PR TITLE
Updating all version numbers, prime bugfix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,8 @@
-Version 2.1 Beta - November 8, 2023
+Version 2.1 - February 29, 2024
    Added reconfiguration capability to Spire
 	* Changes to SCADA Master to support reconfiguration
-	* Uses Prime 4.0 Beta ( Refer to CHANGELOG and README of Prime for details )
-	* Uses Spines 5.6 Beta ( Refer to CHANGELOG of Spines for details )
+	* Uses Prime 4.0  ( Refer to CHANGELOG and README of Prime for details )
+	* Uses Spines 5.6 ( Refer to CHANGELOG of Spines for details )
  	* Minor changes to benchmark and proxy programs to support reconfiguration 
 
 Version 2.0 - January 27, 2023

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@
  *
  * May 17, 2017
  * 
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Power grid SCADA consists of two levels: a control center level and a
 substation level. 
 
 The control-center SCADA monitors and controls many substations and Remote
-Terminal Units (RTUs) and/or Programmable Logic Controllers (PLCs). The control-center-level operations typically have a latency requirement of 100ms-200ms. The
-substation-level critical protection operations have latency requirements as
-low as a quarter-power cycle (For 60Hz, this is 4.167ms). 
+Terminal Units (RTUs) and/or Programmable Logic Controllers (PLCs). The
+control-center-level operations typically have a latency requirement of
+100ms-200ms. The substation-level critical protection operations have latency
+requirements as low as a quarter-power cycle (For 60Hz, this is 4.167ms). 
 
 We have developed Spire as a toolkit that contains modules to support
 intrusion-tolerance for power grid control systems at both the control-center
@@ -58,16 +59,16 @@ devices that use the Modbus or DNP3 communication protocols over IP. We use
 a standalone Machine Learning-based Network Intrusion Detection System that is
 built to work with Spire.
 
-Additionally, Version 2.1 (currently in beta release) adds reconfiguration
-support to Spire. Reconfiguration can be used to improve the operational
-profile of a system. For example: With reconfiguration, if the current system
-configuration (say configuration '6+6+6') becomes non-operational due to loss
-of a control center and data center but at least one control center remains up,
-the system can be reconfigured to that one control center (configuration '6')
-and resume operations. It is also possible to reconfigure preemptively when
-needed (e.g. if one control center becomes non-operational, it is better to
-reconfigure the system to configuration '6' in the remaining control center).
-The reconfiguration modules are implemented as part of the Prime replication
+Additionally, Version 2.1 adds reconfiguration support to Spire.
+Reconfiguration can be used to improve the operational profile of a system. For
+example: With reconfiguration, if the current system configuration (say
+configuration '6+6+6') becomes non-operational due to loss of a control center
+and data center but at least one control center remains up, the system can be
+reconfigured to that one control center (configuration '6') and resume
+operations. It is also possible to reconfigure preemptively when needed (e.g.
+if one control center becomes non-operational, it is better to reconfigure the
+system to configuration '6' in the remaining control center).  The
+reconfiguration modules are implemented as part of the Prime replication
 engine, and include a configuration network, configuration manager and
 configuration agent. The details of the reconfiguration mechanism are in
 `README_Spire.md` and README of Prime.
@@ -151,7 +152,7 @@ Spire for the Substation: `README_Spire_Substation.md`
 
 ## 5. Version Notes
 
-Spire 2.1 Beta adds reconfiguration support to Spire.
+Spire 2.1 adds reconfiguration support to Spire.
 
 Spire 2.0 extends the Spire 1.3 to support real-time
 Byzantine resilience of power grid substations. This release includes Spire for

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/benchmarks_ss/Makefile
+++ b/benchmarks_ss/Makefile
@@ -35,7 +35,7 @@
  #   Samuel Beckley       Contributions to HMIs
  
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced

--- a/benchmarks_ss/benchmark.c
+++ b/benchmarks_ss/benchmark.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced
@@ -520,8 +520,8 @@ static int setup_mcast()
 static void print_notice()
 {
   Alarm( PRINT, "/==================================================================================\\\n");
-  Alarm( PRINT, "| Spire 2.1 Alpha                                                                   |\n");
-  Alarm( PRINT, "| Copyright (c) 2017-2023 Johns Hopkins University                                  |\n");
+  Alarm( PRINT, "| Spire 2.1                                                                         |\n");
+  Alarm( PRINT, "| Copyright (c) 2017-2024 Johns Hopkins University                                  |\n");
   Alarm( PRINT, "| All rights reserved.                                                              |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| Spire is licensed under the Spire Open-Source License.                            |\n");
@@ -542,7 +542,7 @@ static void print_notice()
   Alarm( PRINT, "| WWW:     www.dsn.jhu/spire   www.dsn.jhu.edu                                      |\n");
   Alarm( PRINT, "| Contact: spire@dsn.jhu.edu                                                        |\n");
   Alarm( PRINT, "|                                                                                   |\n");
-  Alarm( PRINT, "| Version 2.1 Alpha, Built Sept 29, 2023                                            |\n");
+  Alarm( PRINT, "| Version 2.1, Built Feb 29, 2024                                                   |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use               |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                         |\n");

--- a/benchmarks_ss/benchmark2.c
+++ b/benchmarks_ss/benchmark2.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced
@@ -582,8 +582,8 @@ static void print_stats()
 static void print_notice()
 {
   Alarm( PRINT, "/==================================================================================\\\n");
-  Alarm( PRINT, "| Spire 2.1 Alpha                                                                   |\n");
-  Alarm( PRINT, "| Copyright (c) 2017-2023 Johns Hopkins University                                  |\n");
+  Alarm( PRINT, "| Spire 2.1                                                                         |\n");
+  Alarm( PRINT, "| Copyright (c) 2017-2024 Johns Hopkins University                                  |\n");
   Alarm( PRINT, "| All rights reserved.                                                              |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| Spire is licensed under the Spire Open-Source License.                            |\n");
@@ -593,7 +593,7 @@ static void print_notice()
   Alarm( PRINT, "| Creators:                                                                         |\n");
   Alarm( PRINT, "|    Yair Amir                 yairamir@cs.jhu.edu                                  |\n");
   Alarm( PRINT, "|    Trevor Aron               taron1@cs.jhu.edu                                    |\n");
-  Alarm( PRINT, "|    Amy Babay                 babay@pitt.edu                                     |\n");
+  Alarm( PRINT, "|    Amy Babay                 babay@pitt.edu                                       |\n");
   Alarm( PRINT, "|    Thomas Tantillo           tantillo@cs.jhu.edu                                  |\n");
   Alarm( PRINT, "|    Sahiti Bommareddy         sahiti@cs.jhu.edu                                    |\n");
   Alarm( PRINT, "|                                                                                   |\n");
@@ -604,7 +604,7 @@ static void print_notice()
   Alarm( PRINT, "| WWW:     www.dsn.jhu/spire   www.dsn.jhu.edu                                      |\n");
   Alarm( PRINT, "| Contact: spire@dsn.jhu.edu                                                        |\n");
   Alarm( PRINT, "|                                                                                   |\n");
-  Alarm( PRINT, "| Version 2.1 Alpha, Built Sept 29, 2023	                                     |\n");
+  Alarm( PRINT, "| Version 2.1, Built Feb 29, 2024        	                                     |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use               |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                         |\n");

--- a/common/conf_itrc.c
+++ b/common/conf_itrc.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_itrc.h
+++ b/common/conf_itrc.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_net_wrapper.c
+++ b/common/conf_net_wrapper.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_net_wrapper.h
+++ b/common/conf_net_wrapper.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_openssl_rsa.c
+++ b/common/conf_openssl_rsa.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_openssl_rsa.h
+++ b/common/conf_openssl_rsa.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_scada_packets.c
+++ b/common/conf_scada_packets.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_scada_packets.h
+++ b/common/conf_scada_packets.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_tc_wrapper.c
+++ b/common/conf_tc_wrapper.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/conf_tc_wrapper.h
+++ b/common/conf_tc_wrapper.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/def.h
+++ b/common/def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/itrc.c
+++ b/common/itrc.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/itrc.h
+++ b/common/itrc.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/key_value.c
+++ b/common/key_value.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/key_value.h
+++ b/common/key_value.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/net_wrapper.c
+++ b/common/net_wrapper.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/net_wrapper.h
+++ b/common/net_wrapper.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/openssl_rsa.c
+++ b/common/openssl_rsa.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/openssl_rsa.h
+++ b/common/openssl_rsa.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/scada_packets.c
+++ b/common/scada_packets.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/scada_packets.h
+++ b/common/scada_packets.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/ss_net_wrapper.c
+++ b/common/ss_net_wrapper.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/ss_net_wrapper.h
+++ b/common/ss_net_wrapper.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/ss_openssl_rsa.c
+++ b/common/ss_openssl_rsa.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/ss_openssl_rsa.h
+++ b/common/ss_openssl_rsa.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/ss_tc_wrapper.c
+++ b/common/ss_tc_wrapper.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/ss_tc_wrapper.h
+++ b/common/ss_tc_wrapper.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/tc_wrapper.c
+++ b/common/tc_wrapper.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/common/tc_wrapper.h
+++ b/common/tc_wrapper.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/config/config_helpers.c
+++ b/config/config_helpers.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/config/config_helpers.h
+++ b/config/config_helpers.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/dnp3/Makefile
+++ b/dnp3/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/dnp3/callback.cpp
+++ b/dnp3/callback.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/dnp3/callback.h
+++ b/dnp3/callback.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/dnp3/channel_listener.h
+++ b/dnp3/channel_listener.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/dnp3/command_container.h
+++ b/dnp3/command_container.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/dnp3/command_sender.cpp
+++ b/dnp3/command_sender.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/dnp3/command_sender.h
+++ b/dnp3/command_sender.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/example_conf/README.txt
+++ b/example_conf/README.txt
@@ -41,4 +41,8 @@ The README.txt in each configuration directory specifies the example IP address
 we chose for each system component. You may need to update the IP addresses in
 the provided configuration files to match your own environment.
 
-Note: The confidential_spire_conf_4+4+3+3 is an example configuration of Confidential Spire and ss_conf_4 is an example for Spire for the Substation. After coping the configurations recompilation is needed in both cases. Instructions for compilation are in their respective READMEs in top-level directory.
+Note: The confidential_spire_conf_4+4+3+3 is an example configuration of
+Confidential Spire and ss_conf_4 is an example for Spire for the Substation.
+After coping the configurations recompilation is needed in both cases.
+Instructions for compilation are in their respective READMEs in top-level
+directory.

--- a/example_conf/conf_3+3+3+3/prime_def.h
+++ b/example_conf/conf_3+3+3+3/prime_def.h
@@ -27,7 +27,7 @@
  *   Brian Coan           Design of the Prime algorithm
  *   Jeff Seibert         View Change protocol 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/example_conf/conf_3+3+3+3/scada_def.h
+++ b/example_conf/conf_3+3+3+3/scada_def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/example_conf/conf_4/prime_def.h
+++ b/example_conf/conf_4/prime_def.h
@@ -27,7 +27,7 @@
  *   Brian Coan           Design of the Prime algorithm
  *   Jeff Seibert         View Change protocol 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/example_conf/conf_4/scada_def.h
+++ b/example_conf/conf_4/scada_def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/example_conf/conf_6+6+6/prime_def.h
+++ b/example_conf/conf_6+6+6/prime_def.h
@@ -27,7 +27,7 @@
  *   Brian Coan           Design of the Prime algorithm
  *   Jeff Seibert         View Change protocol 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/example_conf/conf_6+6+6/scada_def.h
+++ b/example_conf/conf_6+6+6/scada_def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/example_conf/conf_6/prime_def.h
+++ b/example_conf/conf_6/prime_def.h
@@ -27,7 +27,7 @@
  *   Brian Coan           Design of the Prime algorithm
  *   Jeff Seibert         View Change protocol 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/example_conf/conf_6/scada_def.h
+++ b/example_conf/conf_6/scada_def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/example_conf/conf_6_latency_tuned/prime_def.h
+++ b/example_conf/conf_6_latency_tuned/prime_def.h
@@ -27,7 +27,7 @@
  *   Brian Coan           Design of the Prime algorithm
  *   Jeff Seibert         View Change protocol 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/example_conf/conf_6_latency_tuned/scada_def.h
+++ b/example_conf/conf_6_latency_tuned/scada_def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/example_conf/confidential_spire_conf_4+4+3+3/prime_def.h
+++ b/example_conf/confidential_spire_conf_4+4+3+3/prime_def.h
@@ -27,7 +27,7 @@
  *   Brian Coan           Design of the Prime algorithm
  *   Jeff Seibert         View Change protocol 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/example_conf/confidential_spire_conf_4+4+3+3/scada_def.h
+++ b/example_conf/confidential_spire_conf_4+4+3+3/scada_def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/example_conf/ss_conf_4/scada_def.h
+++ b/example_conf/ss_conf_4/scada_def.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/Makefile
+++ b/hmis/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/BARE_Makefile
+++ b/hmis/ems_hmi/BARE_Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/Makefile
+++ b/hmis/ems_hmi/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/common_generator_ui.h
+++ b/hmis/ems_hmi/common_generator_ui.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/ems_hmi.cpp
+++ b/hmis/ems_hmi/ems_hmi.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/mask1.cpp
+++ b/hmis/ems_hmi/mask1.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/mask1_slots.h
+++ b/hmis/ems_hmi/mask1_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/mask2.cpp
+++ b/hmis/ems_hmi/mask2.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/mask2_slots.h
+++ b/hmis/ems_hmi/mask2_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/mask3.cpp
+++ b/hmis/ems_hmi/mask3.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/mask3_slots.h
+++ b/hmis/ems_hmi/mask3_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/master_exec.cpp
+++ b/hmis/ems_hmi/master_exec.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/master_exec.h
+++ b/hmis/ems_hmi/master_exec.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/ems_hmi/pvapp.h
+++ b/hmis/ems_hmi/pvapp.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/BARE_Makefile
+++ b/hmis/heco_3breaker/BARE_Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/Makefile
+++ b/hmis/heco_3breaker/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/heco_hmi.cpp
+++ b/hmis/heco_3breaker/heco_hmi.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/mask1.cpp
+++ b/hmis/heco_3breaker/mask1.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/mask1_slots.h
+++ b/hmis/heco_3breaker/mask1_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/master_exec.cpp
+++ b/hmis/heco_3breaker/master_exec.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/master_exec.h
+++ b/hmis/heco_3breaker/master_exec.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_3breaker/pvapp.h
+++ b/hmis/heco_3breaker/pvapp.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/BARE_Makefile
+++ b/hmis/heco_5breaker/BARE_Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/Makefile
+++ b/hmis/heco_5breaker/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/heco_hmi.cpp
+++ b/hmis/heco_5breaker/heco_hmi.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/mask1.cpp
+++ b/hmis/heco_5breaker/mask1.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/mask1_slots.h
+++ b/hmis/heco_5breaker/mask1_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/master_exec.cpp
+++ b/hmis/heco_5breaker/master_exec.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/master_exec.h
+++ b/hmis/heco_5breaker/master_exec.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_5breaker/pvapp.h
+++ b/hmis/heco_5breaker/pvapp.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/BARE_Makefile
+++ b/hmis/heco_timing/BARE_Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/Makefile
+++ b/hmis/heco_timing/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/heco_hmi.cpp
+++ b/hmis/heco_timing/heco_hmi.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/mask1.cpp
+++ b/hmis/heco_timing/mask1.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/mask1_slots.h
+++ b/hmis/heco_timing/mask1_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/master_exec.cpp
+++ b/hmis/heco_timing/master_exec.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/master_exec.h
+++ b/hmis/heco_timing/master_exec.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/heco_timing/pvapp.h
+++ b/hmis/heco_timing/pvapp.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/BARE_Makefile
+++ b/hmis/jhu_hmi/BARE_Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/Makefile
+++ b/hmis/jhu_hmi/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/jhu_hmi.cpp
+++ b/hmis/jhu_hmi/jhu_hmi.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/mask1.cpp
+++ b/hmis/jhu_hmi/mask1.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/mask1_slots.h
+++ b/hmis/jhu_hmi/mask1_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/master_exec.cpp
+++ b/hmis/jhu_hmi/master_exec.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/master_exec.h
+++ b/hmis/jhu_hmi/master_exec.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/jhu_hmi/pvapp.h
+++ b/hmis/jhu_hmi/pvapp.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/BARE_Makefile
+++ b/hmis/pnnl_hmi/BARE_Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/Makefile
+++ b/hmis/pnnl_hmi/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/mask1.cpp
+++ b/hmis/pnnl_hmi/mask1.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/mask1_slots.h
+++ b/hmis/pnnl_hmi/mask1_slots.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/master_exec.cpp
+++ b/hmis/pnnl_hmi/master_exec.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/master_exec.h
+++ b/hmis/pnnl_hmi/master_exec.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/pnnl_hmi.cpp
+++ b/hmis/pnnl_hmi/pnnl_hmi.cpp
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/hmis/pnnl_hmi/pvapp.h
+++ b/hmis/pnnl_hmi/pvapp.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/capture_scripts/analyzer.py
+++ b/ids/capture_scripts/analyzer.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/capture_scripts/config.py
+++ b/ids/capture_scripts/config.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/capture_scripts/live_capture.py
+++ b/ids/capture_scripts/live_capture.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/capture_scripts/live_test.py
+++ b/ids/capture_scripts/live_test.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/db_scripts/create_db.py
+++ b/ids/db_scripts/create_db.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/db_scripts/create_distinct_features.py
+++ b/ids/db_scripts/create_distinct_features.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/db_scripts/create_per_packet_features.py
+++ b/ids/db_scripts/create_per_packet_features.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/db_scripts/dbDaemon.py
+++ b/ids/db_scripts/dbDaemon.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/dos_scripts/dos_attack.py
+++ b/ids/dos_scripts/dos_attack.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/dos_scripts/dos_attack_v2.py
+++ b/ids/dos_scripts/dos_attack_v2.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/dos_scripts/dos_header.py
+++ b/ids/dos_scripts/dos_header.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/aggregate/AggregateDaemon.py
+++ b/ids/ml/aggregate/AggregateDaemon.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/aggregate/BucketCollection.py
+++ b/ids/ml/aggregate/BucketCollection.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/aggregate/MLPredictor.py
+++ b/ids/ml/aggregate/MLPredictor.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/aggregate/featurize_aggregate.py
+++ b/ids/ml/aggregate/featurize_aggregate.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/aggregate/generate_aggregate.py
+++ b/ids/ml/aggregate/generate_aggregate.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/aggregate/spire_config.py
+++ b/ids/ml/aggregate/spire_config.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/aggregate/train_aggregate.py
+++ b/ids/ml/aggregate/train_aggregate.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/packet/PerPktDaemon.py
+++ b/ids/ml/packet/PerPktDaemon.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/packet/__init__.py
+++ b/ids/ml/packet/__init__.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/packet/featurize_per_pkt.py
+++ b/ids/ml/packet/featurize_per_pkt.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/ml/packet/lof_distinct_tr.py
+++ b/ids/ml/packet/lof_distinct_tr.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/test_scripts/read_db.py
+++ b/ids/test_scripts/read_db.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/ids/test_scripts/read_unique_pkts.py
+++ b/ids/test_scripts/read_unique_pkts.py
@@ -34,7 +34,7 @@ Contributors:
 
   Samuel Beckley        Contributions to HMIs
 
-Copyright (c) 2017-2023 Johns Hopkins University.
+Copyright (c) 2017-2024 Johns Hopkins University.
 All rights reserved.
 
 Partial funding for Spire research was provided by the Defense Advanced 

--- a/init/gen_ini.py
+++ b/init/gen_ini.py
@@ -36,7 +36,7 @@
  #   Samuel Beckley       Contributions HMIs
  
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/modbus/Makefile
+++ b/modbus/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/plcs/Makefile
+++ b/plcs/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/prime/CHANGELOG.txt
+++ b/prime/CHANGELOG.txt
@@ -1,4 +1,4 @@
-Version 4.0 Beta - November 8, 2023
+Version 4.0  - February 29, 2024
     * Added reconfiguration capability to Prime
     * Configuration Manager and Configuration Agent programs are added to support reconfiguration
     * Driver program is added. It is representative of a simple application that can use Prime as replication engine.

--- a/prime/LICENSE.txt
+++ b/prime/LICENSE.txt
@@ -3,7 +3,7 @@
  *
  * May 04, 2010
  * 
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/prime/libspread-util/Changelog
+++ b/prime/libspread-util/Changelog
@@ -1,3 +1,17 @@
+February 29, 2024 v5.1.0
+------------------------
+
+Adds two new utility functions to the API:
+  - DL_set_large_buffers in spu_data_link.h: attempts to increase the send and
+    receive buffer sizes on a given channel
+  - E_dequeue_all_time_events in spu_events.h: cancels all scheduled timed
+    events
+
+Bugfix to memory.c to correctly handle types smaller than sizeof(void*)
+
+Wrap declarations of debugging functions in memory.h with #ifndef NDEBUG to
+clean up warnings
+
 October 27, 2023 v5.0.2
 -----------------------
 

--- a/prime/src/Makefile
+++ b/prime/src/Makefile
@@ -29,7 +29,7 @@
 #    Sahiti Bommareddy    Reconfiguration 
 #    Maher Khan           Reconfiguration 
 #  
-#  Copyright (c) 2008-2023
+#  Copyright (c) 2008-2024
 #  The Johns Hopkins University.
 #  All rights reserved.
 #  

--- a/prime/src/catchup.c
+++ b/prime/src/catchup.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/catchup.h
+++ b/prime/src/catchup.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/conf_tc_wrapper.c
+++ b/prime/src/conf_tc_wrapper.c
@@ -32,7 +32,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/conf_tc_wrapper.h
+++ b/prime/src/conf_tc_wrapper.h
@@ -32,7 +32,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/conf_validate.c
+++ b/prime/src/conf_validate.c
@@ -32,7 +32,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/config_agent.c
+++ b/prime/src/config_agent.c
@@ -306,7 +306,8 @@ void write_to_file(int32u key_type, int32u key_id,int32u key_size,char *currkey)
 int main(int argc, char **argv)
 {
     setlinebuf(stdout);
-    Alarm_set_types(PRINT|STATUS|DEBUG);
+    Alarm_set_types(PRINT);
+    //Alarm_set_types(STATUS|DEBUG);
     Usage(argc,argv);
     OPENSSL_RSA_Init();
     OPENSSL_RSA_Read_Keys(0,RSA_CONFIG_AGENT,"./keys");
@@ -566,9 +567,9 @@ void Usage(int argc, char **argv)
     }else if(*argv[4]=='p'){
 	NON_SM_Flag =1;
     	sscanf(argv[5], "%d", &app_count);
-	Alarm(PRINT,"Applucations count=%d\n",app_count);
+	Alarm(PRINT,"Applications count=%d\n",app_count);
     }else{
-   	Alarm(EXIT,"Unknown node type %c\n",*argv[3]); 
+   	Alarm(EXIT,"Unknown node type %c\n",*argv[4]); 
 	}
 }
 

--- a/prime/src/config_manager.c
+++ b/prime/src/config_manager.c
@@ -326,7 +326,8 @@ void construct_keys_messages(int curr_server_count,char *base_dir){
 int main(int argc, char **argv)
 {
     setlinebuf(stdout);
-    Alarm_set_types(PRINT|STATUS|DEBUG);
+    Alarm_set_types(PRINT);
+    //Alarm_set_types(STATUS|DEBUG);
     Usage(argc,argv);
     OPENSSL_RSA_Init();
     OPENSSL_RSA_Read_Keys(0,RSA_CONFIG_MNGR,"./keys");

--- a/prime/src/data_structs.c
+++ b/prime/src/data_structs.c
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/data_structs.h
+++ b/prime/src/data_structs.h
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/def.h
+++ b/prime/src/def.h
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/driver.c
+++ b/prime/src/driver.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *  	
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/erasure.c
+++ b/prime/src/erasure.c
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/erasure.h
+++ b/prime/src/erasure.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/error_wrapper.c
+++ b/prime/src/error_wrapper.c
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/error_wrapper.h
+++ b/prime/src/error_wrapper.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/generate_keys.c
+++ b/prime/src/generate_keys.c
@@ -32,7 +32,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/merkle.c
+++ b/prime/src/merkle.c
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/merkle.h
+++ b/prime/src/merkle.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/net_types.h
+++ b/prime/src/net_types.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/net_wrapper.c
+++ b/prime/src/net_wrapper.c
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/net_wrapper.h
+++ b/prime/src/net_wrapper.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/network.c
+++ b/prime/src/network.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/network.h
+++ b/prime/src/network.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/nm_process.c
+++ b/prime/src/nm_process.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration
  *
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  *

--- a/prime/src/nm_process.h
+++ b/prime/src/nm_process.h
@@ -27,7 +27,7 @@
  *   Brian Coan           Design of the Prime algorithm
  * Jeff Seibert         View Change protocol
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  *

--- a/prime/src/objects.h
+++ b/prime/src/objects.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/openssl_rsa.c
+++ b/prime/src/openssl_rsa.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/openssl_rsa.h
+++ b/prime/src/openssl_rsa.h
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/order.c
+++ b/prime/src/order.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/order.h
+++ b/prime/src/order.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/packets.c
+++ b/prime/src/packets.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/packets.h
+++ b/prime/src/packets.h
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/pre_order.c
+++ b/prime/src/pre_order.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/pre_order.h
+++ b/prime/src/pre_order.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/prime.c
+++ b/prime/src/prime.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
 
   Alarm( PRINT, "/===========================================================================\\\n");
   Alarm( PRINT, "| Prime                                                                     |\n");
-  Alarm( PRINT, "| Copyright (c) 2010 - 2020 Johns Hopkins University                        |\n"); 
+  Alarm( PRINT, "| Copyright (c) 2010 - 2024 Johns Hopkins University                        |\n"); 
   Alarm( PRINT, "| All rights reserved.                                                      |\n");
   Alarm( PRINT, "|                                                                           |\n");
   Alarm( PRINT, "| Prime is licensed under the Prime Open-Source License.                    |\n");
@@ -99,11 +99,13 @@ int main(int argc, char** argv)
   Alarm( PRINT, "| Major Contributors:                                                       |\n");
   Alarm( PRINT, "|    Brian Coan                Design of the Prime algorithm                |\n");
   Alarm( PRINT, "|    Jeff Seibert              View Change protocol                         |\n");
+  Alarm( PRINT, "|    Sahiti Bommareddy         Reconfiguration                              |\n");
+  Alarm( PRINT, "|    Maher Khan                Reconfiguration                              |\n");
   Alarm( PRINT, "|                                                                           |\n");
   Alarm( PRINT, "| WWW:     www.dsn.jhu/prime   www.dsn.jhu.edu                              |\n");
   Alarm( PRINT, "| Contact: prime@dsn.jhu.edu                                                |\n");
   Alarm( PRINT, "|                                                                           |\n");
-  Alarm( PRINT, "| Version 4.0 Beta, Built November 8, 2023                                  |\n"); 
+  Alarm( PRINT, "| Version 4.0, Built February 29, 2024                                      |\n"); 
   Alarm( PRINT, "|                                                                           |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use       |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                 |\n");

--- a/prime/src/proactive_recovery.c
+++ b/prime/src/proactive_recovery.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/proactive_recovery.h
+++ b/prime/src/proactive_recovery.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/process.c
+++ b/prime/src/process.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/process.h
+++ b/prime/src/process.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/recon.c
+++ b/prime/src/recon.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/recon.h
+++ b/prime/src/recon.h
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/reliable_broadcast.c
+++ b/prime/src/reliable_broadcast.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/reliable_broadcast.h
+++ b/prime/src/reliable_broadcast.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/signature.c
+++ b/prime/src/signature.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/signature.h
+++ b/prime/src/signature.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/stopwatch.h
+++ b/prime/src/stopwatch.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/suspect_leader.c
+++ b/prime/src/suspect_leader.c
@@ -31,7 +31,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/suspect_leader.h
+++ b/prime/src/suspect_leader.h
@@ -32,7 +32,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/tc_wrapper.c
+++ b/prime/src/tc_wrapper.c
@@ -97,8 +97,10 @@ void TC_Read_Public_Key(char *dir)
     for ( nsite = 1; nsite <= NUM_SITES; nsite++ ) {
 	    sprintf(buf,"%s/pubkey_%d.pem", dir, nsite);
 	    tc_public_key[nsite] = (TC_PK *)TC_read_public_key(buf);
-	    sprintf(buff2,"%s/pubkey_%d.pem", dir2, nsite);
-	    tc_sm_public_key[nsite] = (TC_PK *)TC_read_public_key(buff2);
+            if(CONFIDENTIAL){
+	       sprintf(buff2,"%s/pubkey_%d.pem", dir2, nsite);
+	       tc_sm_public_key[nsite] = (TC_PK *)TC_read_public_key(buff2);
+	    }
     }
 }
 

--- a/prime/src/tc_wrapper.c
+++ b/prime/src/tc_wrapper.c
@@ -32,7 +32,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/tc_wrapper.h
+++ b/prime/src/tc_wrapper.h
@@ -32,7 +32,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/util_dll.c
+++ b/prime/src/util_dll.c
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/util_dll.h
+++ b/prime/src/util_dll.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/utility.c
+++ b/prime/src/utility.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/utility.h
+++ b/prime/src/utility.h
@@ -30,7 +30,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/validate.c
+++ b/prime/src/validate.c
@@ -29,7 +29,7 @@
  *   Sahiti Bommareddy    Reconfiguration 
  *   Maher Khan           Reconfiguration 
  * 
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/validate.h
+++ b/prime/src/validate.h
@@ -31,7 +31,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/view_change.c
+++ b/prime/src/view_change.c
@@ -31,7 +31,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/prime/src/view_change.h
+++ b/prime/src/view_change.h
@@ -32,7 +32,7 @@
  * 
  *
  *      
- * Copyright (c) 2008-2023
+ * Copyright (c) 2008-2024
  * The Johns Hopkins University.
  * All rights reserved.
  * 

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/proxy/proxy.c
+++ b/proxy/proxy.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/proxy_iec61850/Makefile
+++ b/proxy_iec61850/Makefile
@@ -35,7 +35,7 @@
  #   Samuel Beckley       Contributions to HMIs
  
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced

--- a/proxy_iec61850/counting_brkr_proxy.c
+++ b/proxy_iec61850/counting_brkr_proxy.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced
@@ -609,8 +609,8 @@ static void PROXY_Send_Breaker_Ack()
 static void print_notice()
 {
   Alarm( PRINT, "/==================================================================================\\\n");
-  Alarm( PRINT, "| Spire 2.1 Beta                                                                    |\n");
-  Alarm( PRINT, "| Copyright (c) 2017-2023 Johns Hopkins University                                  |\n");
+  Alarm( PRINT, "| Spire 2.1                                                                         |\n");
+  Alarm( PRINT, "| Copyright (c) 2017-2024 Johns Hopkins University                                  |\n");
   Alarm( PRINT, "| All rights reserved.                                                              |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| Spire is licensed under the Spire Open-Source License.                            |\n");
@@ -631,7 +631,7 @@ static void print_notice()
   Alarm( PRINT, "| WWW:     www.dsn.jhu/spire   www.dsn.jhu.edu                                      |\n");
   Alarm( PRINT, "| Contact: spire@dsn.jhu.edu                                                        |\n");
   Alarm( PRINT, "|                                                                                   |\n");
-  Alarm( PRINT, "| Version 2.1 Beta, Built Nov 8, 2023                                               |\n");
+  Alarm( PRINT, "| Version 2.1, Built Feb 29, 2024                                                   |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use               |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                         |\n");

--- a/proxy_iec61850/pnnl_relay_proxy.c
+++ b/proxy_iec61850/pnnl_relay_proxy.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced
@@ -353,8 +353,8 @@ static void goose_listener(GooseSubscriber subscriber, void* parameter)
 static void print_notice()
 {
   Alarm( PRINT, "/==================================================================================\\\n");
-  Alarm( PRINT, "| Spire 2.1 Beta                                                                    |\n");
-  Alarm( PRINT, "| Copyright (c) 2017-2023 Johns Hopkins University                                  |\n");
+  Alarm( PRINT, "| Spire 2.1                                                                         |\n");
+  Alarm( PRINT, "| Copyright (c) 2017-2024 Johns Hopkins University                                  |\n");
   Alarm( PRINT, "| All rights reserved.                                                              |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| Spire is licensed under the Spire Open-Source License.                            |\n");
@@ -375,7 +375,7 @@ static void print_notice()
   Alarm( PRINT, "| WWW:     www.dsn.jhu/spire   www.dsn.jhu.edu                                      |\n");
   Alarm( PRINT, "| Contact: spire@dsn.jhu.edu                                                        |\n");
   Alarm( PRINT, "|                                                                                   |\n");
-  Alarm( PRINT, "| Version 2.1 Beta, Built Nov 8, 2023                                               |\n");
+  Alarm( PRINT, "| Version 2.1, Built Feb 29, 2024                                                   |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use               |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                         |\n");

--- a/proxy_iec61850/pnnl_simple_cb_proxy.c
+++ b/proxy_iec61850/pnnl_simple_cb_proxy.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced
@@ -525,8 +525,8 @@ static void PROXY_Send_Breaker_Ack()
 static void print_notice()
 {
   Alarm( PRINT, "/==================================================================================\\\n");
-  Alarm( PRINT, "| Spire 2.1 Beta                                                                    |\n");
-  Alarm( PRINT, "| Copyright (c) 2017-2023 Johns Hopkins University                                  |\n");
+  Alarm( PRINT, "| Spire 2.1                                                                         |\n");
+  Alarm( PRINT, "| Copyright (c) 2017-2024 Johns Hopkins University                                  |\n");
   Alarm( PRINT, "| All rights reserved.                                                              |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| Spire is licensed under the Spire Open-Source License.                            |\n");
@@ -547,7 +547,7 @@ static void print_notice()
   Alarm( PRINT, "| WWW:     www.dsn.jhu/spire   www.dsn.jhu.edu                                      |\n");
   Alarm( PRINT, "| Contact: spire@dsn.jhu.edu                                                        |\n");
   Alarm( PRINT, "|                                                                                   |\n");
-  Alarm( PRINT, "| Version 2.1 Beta, Built Nov 8, 2023                                               |\n");
+  Alarm( PRINT, "| Version 2.1, Built Feb 29, 2024                                                   |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use               |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                         |\n");

--- a/relay_emulator/Makefile
+++ b/relay_emulator/Makefile
@@ -35,7 +35,7 @@
  #   Samuel Beckley       Contributions to HMIs
  
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced

--- a/relay_emulator/README.md
+++ b/relay_emulator/README.md
@@ -1,5 +1,14 @@
-The emulated relays are capable of publishing GOOSE messages with TRIP and CLOSE payloads.Hence names goose_publisher.
-The GOOSE pattern will be the current state will be published every T0 (2000milli sec). When it receives SV message indicating a new event. It increasing state number and  publishes the event immediately or with delay indicated in SV payload. This repeats after T1(500milli sec) with increasing sequence number. The repeation interval doubles until it hits T0. 
+The emulated relays are capable of publishing GOOSE messages with TRIP and
+CLOSE payloads.Hence named goose_publisher.  The emulated relay's GOOSE pattern
+will be the current state published every T0 (2000milli sec). When it receives
+SV message indicating a new event, emulated relay increasing state number and
+publishes the event immediately or with delay indicated in SV payload. This
+repeats after T1(500milli sec) with increasing sequence number. The repeation
+interval doubles until it hits T0. 
 
 
-The SV messages are dummy messages sent by gen event program. To generate simple close the command is "s 0", while trip is "s 1". To generate byzantine behaviour "b delay1 t/c_1 dleay_2 t/c_2 delay_3 t/c_3 delay_4 t/c_4". If we want any relay to be silent make payload other than t/c. t is 1 , c is 0.
+The SV messages are dummy messages sent by gen event program. To generate
+simple close the command is "s 0", while trip is "s 1". To generate byzantine
+behaviour "b delay1 t/c_1 dleay_2 t/c_2 delay_3 t/c_3 delay_4 t/c_4". If we
+want any relay to be silent make payload other than t/c. t is 1 , c is 0 and
+the delay is in milliseconds.

--- a/relay_emulator/gen_event.c
+++ b/relay_emulator/gen_event.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/relay_emulator/goose_publisher.c
+++ b/relay_emulator/goose_publisher.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/scada_master/Makefile
+++ b/scada_master/Makefile
@@ -35,7 +35,7 @@
  # Contributors:
  #   Samuel Beckley       Contributions to HMIs 
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced 

--- a/scada_master/conf_generate_keys.c
+++ b/scada_master/conf_generate_keys.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/scada_master/conf_scada_master.c
+++ b/scada_master/conf_scada_master.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/scada_master/generate_keys.c
+++ b/scada_master/generate_keys.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/scada_master/queue.c
+++ b/scada_master/queue.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/scada_master/queue.h
+++ b/scada_master/queue.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/scada_master/scada_master.c
+++ b/scada_master/scada_master.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/scada_master/structs.h
+++ b/scada_master/structs.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced 

--- a/spines/CHANGELOG
+++ b/spines/CHANGELOG
@@ -1,4 +1,4 @@
-Version 5.6 Beta - November 8, 2023
+Version 5.6 - February 29, 2024
     * Changes to be compatible with latest versions of GCC
 
 Version 5.5 - December 23, 2020

--- a/spines/controlprogs/setdissem.c
+++ b/spines/controlprogs/setdissem.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/controlprogs/setlink.c
+++ b/spines/controlprogs/setlink.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/arch.h
+++ b/spines/daemon/arch.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/conf_body.h
+++ b/spines/daemon/conf_body.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/config_gram.l
+++ b/spines/daemon/config_gram.l
@@ -20,7 +20,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/config_parse.y
+++ b/spines/daemon/config_parse.y
@@ -20,7 +20,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain, 
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/configuration.c
+++ b/spines/daemon/configuration.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/configuration.h
+++ b/spines/daemon/configuration.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/defines.h
+++ b/spines/daemon/defines.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/dissem_graphs.c
+++ b/spines/daemon/dissem_graphs.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/dissem_graphs.h
+++ b/spines/daemon/dissem_graphs.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/hello.c
+++ b/spines/daemon/hello.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/hello.h
+++ b/spines/daemon/hello.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/intrusion_tol_udp.c
+++ b/spines/daemon/intrusion_tol_udp.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/intrusion_tol_udp.h
+++ b/spines/daemon/intrusion_tol_udp.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/kernel_routing.c
+++ b/spines/daemon/kernel_routing.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/kernel_routing.h
+++ b/spines/daemon/kernel_routing.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/link.c
+++ b/spines/daemon/link.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/link.h
+++ b/spines/daemon/link.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/link_state.c
+++ b/spines/daemon/link_state.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/link_state.h
+++ b/spines/daemon/link_state.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/multicast.c
+++ b/spines/daemon/multicast.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/multicast.h
+++ b/spines/daemon/multicast.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/multipath.c
+++ b/spines/daemon/multipath.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/multipath.h
+++ b/spines/daemon/multipath.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/net_types.h
+++ b/spines/daemon/net_types.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/network.c
+++ b/spines/daemon/network.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/network.h
+++ b/spines/daemon/network.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/node.c
+++ b/spines/daemon/node.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/node.h
+++ b/spines/daemon/node.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/objects.h
+++ b/spines/daemon/objects.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/priority_flood.c
+++ b/spines/daemon/priority_flood.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/priority_flood.h
+++ b/spines/daemon/priority_flood.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/protocol.c
+++ b/spines/daemon/protocol.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/protocol.h
+++ b/spines/daemon/protocol.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/realtime_udp.c
+++ b/spines/daemon/realtime_udp.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/realtime_udp.h
+++ b/spines/daemon/realtime_udp.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_datagram.c
+++ b/spines/daemon/reliable_datagram.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_datagram.h
+++ b/spines/daemon/reliable_datagram.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_flood.c
+++ b/spines/daemon/reliable_flood.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_flood.h
+++ b/spines/daemon/reliable_flood.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_session.c
+++ b/spines/daemon/reliable_session.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_session.h
+++ b/spines/daemon/reliable_session.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_udp.c
+++ b/spines/daemon/reliable_udp.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/reliable_udp.h
+++ b/spines/daemon/reliable_udp.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/route.c
+++ b/spines/daemon/route.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/route.h
+++ b/spines/daemon/route.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/security.c
+++ b/spines/daemon/security.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/security.h
+++ b/spines/daemon/security.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/session.c
+++ b/spines/daemon/session.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/session.h
+++ b/spines/daemon/session.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/spines.c
+++ b/spines/daemon/spines.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):
@@ -341,7 +341,7 @@ int main(int argc, char* argv[])
 
     Alarm( PRINT, "/===========================================================================\\\n");
     Alarm( PRINT, "| Spines                                                                    |\n");
-    Alarm( PRINT, "| Copyright (c) 2003 - 2020 Johns Hopkins University                        |\n"); 
+    Alarm( PRINT, "| Copyright (c) 2003 - 2024 Johns Hopkins University                        |\n"); 
     Alarm( PRINT, "| All rights reserved.                                                      |\n");
     Alarm( PRINT, "|                                                                           |\n");
     Alarm( PRINT, "| Spines is licensed under the Spines Open-Source License.                  |\n");
@@ -368,7 +368,7 @@ int main(int argc, char* argv[])
     Alarm( PRINT, "| WWW:     www.spines.org      www.dsn.jhu.edu                              |\n");
     Alarm( PRINT, "| Contact: spines@spines.org                                                |\n");
     Alarm( PRINT, "|                                                                           |\n");
-    Alarm( PRINT, "| Version 5.6, Built November 8, 2023                                       |\n"); 
+    Alarm( PRINT, "| Version 5.7, Built February 29, 2024                                      |\n"); 
     Alarm( PRINT, "|                                                                           |\n");
     Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use       |\n");
     Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                 |\n");

--- a/spines/daemon/spines.h
+++ b/spines/daemon/spines.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/state_flood.c
+++ b/spines/daemon/state_flood.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/state_flood.h
+++ b/spines/daemon/state_flood.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/udp.c
+++ b/spines/daemon/udp.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/udp.h
+++ b/spines/daemon/udp.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/wireless.c
+++ b/spines/daemon/wireless.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/daemon/wireless.h
+++ b/spines/daemon/wireless.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/libspines/spines_lib.c
+++ b/spines/libspines/spines_lib.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/libspines/spines_lib.h
+++ b/spines/libspines/spines_lib.h
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/libspread-util/Changelog
+++ b/spines/libspread-util/Changelog
@@ -1,3 +1,17 @@
+February 29, 2024 v5.1.0
+------------------------
+
+Adds two new utility functions to the API:
+  - DL_set_large_buffers in spu_data_link.h: attempts to increase the send and
+    receive buffer sizes on a given channel
+  - E_dequeue_all_time_events in spu_events.h: cancels all scheduled timed
+    events
+
+Bugfix to memory.c to correctly handle types smaller than sizeof(void*)
+
+Wrap declarations of debugging functions in memory.h with #ifndef NDEBUG to
+clean up warnings
+
 October 27, 2023 v5.0.2
 -----------------------
 

--- a/spines/testprogs/g_flooder.c
+++ b/spines/testprogs/g_flooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/mcast_recv.c
+++ b/spines/testprogs/mcast_recv.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/new_t_flooder.c
+++ b/spines/testprogs/new_t_flooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/port2spines.c
+++ b/spines/testprogs/port2spines.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_bflooder.c
+++ b/spines/testprogs/sp_bflooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_groups.c
+++ b/spines/testprogs/sp_groups.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_groups_send.c
+++ b/spines/testprogs/sp_groups_send.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_join_one.c
+++ b/spines/testprogs/sp_join_one.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_multisession.c
+++ b/spines/testprogs/sp_multisession.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_ping.c
+++ b/spines/testprogs/sp_ping.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_rmcast.c
+++ b/spines/testprogs/sp_rmcast.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_rmcast_tree_change.c
+++ b/spines/testprogs/sp_rmcast_tree_change.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_rmflooder.c
+++ b/spines/testprogs/sp_rmflooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_send_one.c
+++ b/spines/testprogs/sp_send_one.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_tflooder.c
+++ b/spines/testprogs/sp_tflooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_uflooder.c
+++ b/spines/testprogs/sp_uflooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sp_xcast.c
+++ b/spines/testprogs/sp_xcast.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/spines2port.c
+++ b/spines/testprogs/spines2port.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/sping.c
+++ b/spines/testprogs/sping.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/t_flooder.c
+++ b/spines/testprogs/t_flooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/spines/testprogs/u_flooder.c
+++ b/spines/testprogs/u_flooder.c
@@ -19,7 +19,7 @@
  *  Yair Amir, Claudiu Danilov, John Schultz, Daniel Obenshain,
  *  Thomas Tantillo, and Amy Babay.
  *
- * Copyright (c) 2003-2020 The Johns Hopkins University.
+ * Copyright (c) 2003-2024 The Johns Hopkins University.
  * All rights reserved.
  *
  * Major Contributor(s):

--- a/trip_master/Makefile
+++ b/trip_master/Makefile
@@ -35,7 +35,7 @@
  #   Samuel Beckley       Contributions to HMIs
  
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/data_structs.c
+++ b/trip_master/data_structs.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/data_structs.h
+++ b/trip_master/data_structs.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/decision.c
+++ b/trip_master/decision.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/decision.h
+++ b/trip_master/decision.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/gen_keys.c
+++ b/trip_master/gen_keys.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/receiver.c
+++ b/trip_master/receiver.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/receiver.h
+++ b/trip_master/receiver.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/recovery.c
+++ b/trip_master/recovery.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/recovery.h
+++ b/trip_master/recovery.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/trip_master.c
+++ b/trip_master/trip_master.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced
@@ -114,8 +114,8 @@ int main(int argc, char** argv)
 static void print_notice()
 {
   Alarm( PRINT, "/==================================================================================\\\n");
-  Alarm( PRINT, "| Spire 2.1 Beta                                                                    |\n");
-  Alarm( PRINT, "| Copyright (c) 2017-2023 Johns Hopkins University                                  |\n");
+  Alarm( PRINT, "| Spire 2.1                                                                         |\n");
+  Alarm( PRINT, "| Copyright (c) 2017-2024 Johns Hopkins University                                  |\n");
   Alarm( PRINT, "| All rights reserved.                                                              |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| Spire is licensed under the Spire Open-Source License.                            |\n");
@@ -136,7 +136,7 @@ static void print_notice()
   Alarm( PRINT, "| WWW:     www.dsn.jhu/spire   www.dsn.jhu.edu                                      |\n");
   Alarm( PRINT, "| Contact: spire@dsn.jhu.edu                                                        |\n");
   Alarm( PRINT, "|                                                                                   |\n");
-  Alarm( PRINT, "| Version 2.1 Beta , Built Nov 8  , 2023                                            |\n");
+  Alarm( PRINT, "| Version 2.1, Built Feb 29  , 2024                                                 |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use               |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                         |\n");

--- a/trip_master/utility.c
+++ b/trip_master/utility.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master/utility.h
+++ b/trip_master/utility.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/Makefile
+++ b/trip_master_v2/Makefile
@@ -35,7 +35,7 @@
  #   Samuel Beckley       Contributions to HMIs
  
  #
- # Copyright (c) 2017-2023 Johns Hopkins University.
+ # Copyright (c) 2017-2024 Johns Hopkins University.
  # All rights reserved.
  #
  # Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/data_structs.c
+++ b/trip_master_v2/data_structs.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/data_structs.h
+++ b/trip_master_v2/data_structs.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/decision.c
+++ b/trip_master_v2/decision.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/decision.h
+++ b/trip_master_v2/decision.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/gen_keys.c
+++ b/trip_master_v2/gen_keys.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/receiver.c
+++ b/trip_master_v2/receiver.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/receiver.h
+++ b/trip_master_v2/receiver.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/recovery.c
+++ b/trip_master_v2/recovery.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/recovery.h
+++ b/trip_master_v2/recovery.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/trip_master.c
+++ b/trip_master_v2/trip_master.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced
@@ -111,8 +111,8 @@ int main(int argc, char** argv)
 static void print_notice()
 {
   Alarm( PRINT, "/==================================================================================\\\n");
-  Alarm( PRINT, "| Spire 2.1 Beta                                                                    |\n");
-  Alarm( PRINT, "| Copyright (c) 2017-2023 Johns Hopkins University                                  |\n");
+  Alarm( PRINT, "| Spire 2.1                                                                         |\n");
+  Alarm( PRINT, "| Copyright (c) 2017-2024 Johns Hopkins University                                  |\n");
   Alarm( PRINT, "| All rights reserved.                                                              |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| Spire is licensed under the Spire Open-Source License.                            |\n");
@@ -133,7 +133,7 @@ static void print_notice()
   Alarm( PRINT, "| WWW:     www.dsn.jhu/spire   www.dsn.jhu.edu                                      |\n");
   Alarm( PRINT, "| Contact: spire@dsn.jhu.edu                                                        |\n");
   Alarm( PRINT, "|                                                                                   |\n");
-  Alarm( PRINT, "| Version 2.1 Beta, Built Nov 8, 2023                                               |\n");
+  Alarm( PRINT, "| Version 2.1, Built Feb 29, 2024                                                   |\n");
   Alarm( PRINT, "|                                                                                   |\n");
   Alarm( PRINT, "| This product uses software developed by Spread Concepts LLC for use               |\n");
   Alarm( PRINT, "| in the Spread toolkit. For more information about Spread,                         |\n");

--- a/trip_master_v2/utility.c
+++ b/trip_master_v2/utility.c
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced

--- a/trip_master_v2/utility.h
+++ b/trip_master_v2/utility.h
@@ -34,7 +34,7 @@
  * Contributors:
  *   Samuel Beckley       Contributions to HMIs
  *
- * Copyright (c) 2017-2023 Johns Hopkins University.
+ * Copyright (c) 2017-2024 Johns Hopkins University.
  * All rights reserved.
  *
  * Partial funding for Spire research was provided by the Defense Advanced


### PR DESCRIPTION
Updates all version numbers for 2.1 release of Spire (and corresponding Spines/Prime releases), fixes minor bug in confidential version of Prime, turns off debugging prints by default